### PR TITLE
Use official docs URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Access UK official statistics from the 'Nomis' database.
     statistics and other economic and demographic data from the Office for 
     National Statistics, based around statistical geographies. See 
     <https://www.nomisweb.co.uk/api/v01/help> for full API documentation.
-URL: https://github.com/ropensci/nomisr, https://docs.evanodell.com/nomisr
+URL: https://github.com/ropensci/nomisr, https://docs.ropensci.org/nomisr
 BugReports: https://github.com/ropensci/nomisr/issues
 License: MIT + file LICENSE
 Depends: R (>= 3.4.0)


### PR DESCRIPTION
We have started to [automatically build docs for all packages](https://ropensci.org/technotes/2019/06/07/ropensci-docs/) so if you'd like you can use the official homepage in your description. But if you prefer your own copy of the site, that's fine too.